### PR TITLE
Ho229の出撃コストを修正

### DIFF
--- a/src/classes/calculator.ts
+++ b/src/classes/calculator.ts
@@ -290,8 +290,8 @@ export default class Calculator {
         }
         continue;
       }
-      // 鋼材のお支払い
-      usedSteel += Math.round(item.slot * item.data.cost * 0.2);
+      // 鋼材のお支払い 重噴式(Ho229等)は1.2倍
+      usedSteel += Math.round(item.slot * item.data.cost * 0.2 * (item.data.isHeavyJet ? 1.2 : 1));
 
       // ====== STAGE1 ======
       // ジェット補正で0.6倍 切り捨て 確保固定

--- a/src/classes/item/item.ts
+++ b/src/classes/item/item.ts
@@ -322,7 +322,12 @@ export default class Item {
       this.fuel = this.fullSlot;
       this.ammo = Math.ceil(this.fullSlot * 0.6);
       this.bauxite = this.data.cost * (this.data.isRecon ? 4 : 18);
-      this.steel = this.data.isJet ? Math.round(this.fullSlot * this.data.cost * 0.2) : 0;
+      if (this.data.isJet) {
+        const steelMultiplier = this.data.isHeavyJet ? 1.2 : 1;
+        this.steel = Math.round(this.fullSlot * this.data.cost * 0.2 * steelMultiplier);
+      } else {
+        this.steel = 0;
+      }
 
       if (this.data.isABAttacker) {
         // 陸攻補正

--- a/src/classes/item/itemMaster.ts
+++ b/src/classes/item/itemMaster.ts
@@ -110,6 +110,9 @@ export default class ItemMaster {
   /** 噴式機フラグ */
   public readonly isJet: boolean;
 
+  /** 重噴式フラグ (Ho229 等) */
+  public readonly isHeavyJet: boolean;
+
   /** カテゴリ(爆戦)フラグ */
   public readonly isBakusen: boolean;
 
@@ -220,7 +223,10 @@ export default class ItemMaster {
     this.isRocket = Const.ROCKET.includes(this.id);
     this.isLateModelTorpedo = Const.LATE_MODEL_TORPEDO.includes(this.id);
     this.isShinzan = Const.AB_ATTACKERS_LARGE.includes(this.apiTypeId);
+    // 噴式機判定
     this.isJet = this.apiTypeId === 57;
+    // 重噴式 (Ho229) 判定: アイコン種別 59
+    this.isHeavyJet = this.iconTypeId === 59;
     this.enabledAttackLandBase = Const.ENABLED_LAND_BASE_ATTACK.includes(this.id);
     this.isStrictDepthCharge = Const.STRICT_DEPTH_CHARGE.includes(this.id);
     this.isTorpedoAttacker = [8, 47, 53].includes(this.apiTypeId);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -28,7 +28,7 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   state: {
     /** サイトバージョン */
-    siteVersion: '2.49.4',
+    siteVersion: '2.49.5',
     /** 装備マスタデータ */
     items: [] as ItemMaster[],
     /** 艦船マスタデータ */


### PR DESCRIPTION
### 概要
Ho229（重噴式）の鋼材消費が通常ジェットより 1.2 倍である仕様に対応。
Close #15