### PR TITLE
「全てのタブを閉じる」機能を追加

### DIFF
--- a/src/components/saveData/SaveDataTab.vue
+++ b/src/components/saveData/SaveDataTab.vue
@@ -81,7 +81,10 @@
           </v-btn>
         </div>
       </div>
-      <div class="tab-add-button">
+      <div class="tab-add-button d-flex">
+        <v-btn icon small @click.stop="closeAllTabs()">
+          <v-icon small>mdi-close-box-multiple</v-icon>
+        </v-btn>
         <v-btn icon small @click.stop="addNewFile()">
           <v-icon small>mdi-plus</v-icon>
         </v-btn>
@@ -549,6 +552,12 @@ export default Vue.extend({
       this.saveData.childItems.push(data);
 
       this.clickSaveData(data);
+    },
+    closeAllTabs() {
+      const dataToClose = [...this.viewData];
+      dataToClose.forEach((data) => {
+        this.closeTab(data);
+      });
     },
     keydownHandler(event: KeyboardEvent) {
       if (event.ctrlKey && event.code === 'KeyS') {


### PR DESCRIPTION
# 「全てのタブを閉じる」機能を追加

## 概要
開いている全てのタブを一括で閉じるための「全て閉じる（close-box-multiple）」ボタンを追加しました。

### 主な変更点
- **UI追加**: `SaveDataTab.vue` のタブ追加（新規ファイル作成）ボタンの隣に、新たに「全てのタブを閉じる」ボタンを設置しました。
- **機能実装**: `closeAllTabs` メソッドを実装し、現在開いている全ての編成タブに対して一括で閉じる処理を実行するようにしました。

## 動作確認手順

### 操作確認
1. アプリ上で複数の編成タブを開きます。
2. タブ右側の操作パネル内にある「全て閉じる（`mdi-close-box-multiple` アイコン）」ボタンをクリックします。
<img width="1067" height="120" alt="image" src="https://github.com/user-attachments/assets/4662fcdb-c111-4dc5-a094-89e2e190b7c8" />

3. 開いている全てのタブが適切に閉じられることを確認します。
<img width="842" height="83" alt="image" src="https://github.com/user-attachments/assets/36e35de6-6f29-4b3b-b7b5-1f95a073a661" />


